### PR TITLE
fix: flakiness in org.json.junit.JSONMLTest#testToJSONObject_reversibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'com.jayway.jsonpath:json-path:2.1.0'
     testImplementation 'org.mockito:mockito-core:4.2.0'
+    testImplementation 'org.skyscreamer:jsonassert:1.5.1'
 }
 
 subprojects {

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,13 @@
             <version>4.2.0</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.skyscreamer/jsonassert -->
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/org/json/junit/JSONMLTest.java
+++ b/src/test/java/org/json/junit/JSONMLTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.*;
 
 import org.json.*;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * Tests for org.json.JSONML.java
@@ -763,7 +764,7 @@ public class JSONMLTest {
         final JSONObject revertedObject = JSONML.toJSONObject(xml, false);
         final String newJson = revertedObject.toString();
         assertTrue("JSON Objects are not similar",originalObject.similar(revertedObject));
-        assertEquals("original JSON does not equal the new JSON",originalJson, newJson);
+        JSONAssert.assertEquals("original JSON does not equal the new JSON", originalJson, newJson, false);
     }
 
 // these tests do not pass for the following reasons:


### PR DESCRIPTION
###### Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
The string in the assertion can change, because the Map which is used to store the data in the JSONObject returns the data in non-deterministic order.
The flaky test was found by using the [NonDex](https://mvnrepository.com/artifact/edu.illinois/nondex-maven-plugin) tool.


###### Solution:
Change the assertion is to a JSONAssertion (e.g. the order of child elements in an element do not matter)

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
The test is deterministic and not flaky. This improves the quality of the test and reduces the time to search for the bug during future development.

###### Reproduce:
```shell
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.json.junit.JSONMLTest#testToJSONObject_reversibility
``` 

