### PR TITLE
fix: flakiness in org.json.junit.JSONObjectTest#valueToString

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'com.jayway.jsonpath:json-path:2.1.0'
     testImplementation 'org.mockito:mockito-core:4.2.0'
+    testImplementation 'org.skyscreamer:jsonassert:1.5.1'
 }
 
 subprojects {

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,13 @@
             <version>4.2.0</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.skyscreamer/jsonassert -->
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -57,6 +57,7 @@ import org.junit.Test;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * JSONObject, along with JSONArray, are the central classes of the reference app.
@@ -2025,8 +2026,8 @@ public class JSONObjectTest {
                 "\"key3\":\"val3\""+
              "}";
         JSONObject jsonObject = new JSONObject(jsonObjectStr);
-        assertTrue("jsonObject valueToString() incorrect",
-                JSONObject.valueToString(jsonObject).equals(jsonObject.toString()));
+        JSONAssert.assertEquals("jsonObject valueToString() incorrect",
+                                JSONObject.valueToString(jsonObject), jsonObject.toString(), false);
         String jsonArrayStr = 
             "[1,2,3]";
         JSONArray jsonArray = new JSONArray(jsonArrayStr);
@@ -2036,8 +2037,8 @@ public class JSONObjectTest {
         map.put("key1", "val1");
         map.put("key2", "val2");
         map.put("key3", "val3");
-        assertTrue("map valueToString() incorrect",
-                jsonObject.toString().equals(JSONObject.valueToString(map))); 
+        JSONAssert.assertEquals("map valueToString() incorrect",
+                jsonObject.toString(), JSONObject.valueToString(map), false);
         Collection<Integer> collection = new ArrayList<Integer>();
         collection.add(Integer.valueOf(1));
         collection.add(Integer.valueOf(2));


### PR DESCRIPTION
## Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
The string in the assertion can change, because the Map which is used to store the data in the JSONObject returns the data in non-deterministic order (the order of child elements in JSON strings do not matter, and JSON strings are equal regardless of the ordering of the elements on the same hierarchy level)
The flaky test was found by using the [NonDex](https://mvnrepository.com/artifact/edu.illinois/nondex-maven-plugin) tool.

The flakiness was discovered on the following lines
https://github.com/hofi1/JSON-java/blob/01727fd0ed00c1f1f5582bdc97244356ac029f3b/src/test/java/org/json/junit/JSONObjectTest.java#L2028-L2029

as well as 
https://github.com/hofi1/JSON-java/blob/01727fd0ed00c1f1f5582bdc97244356ac029f3b/src/test/java/org/json/junit/JSONObjectTest.java#L2039-L2040


## Solution:
Changed the assert statement from a JUnit Assertion to a JSON Assertion, so the strings are not compared charwise but are compared the way as specified for JSON strings (not taking care of the order of the elements on the same level).
The JSONAssertion library was chosen because it provides general assertions to compare JSON strings without the need of writing complex JUnit Assertions, what would need a lot of work to convert the strings in a different data structure, a lot of boilerplate code as well as the chance of adding more errors than fixing. 

## Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
The test is deterministic and not flaky. This improves the quality of the test and reduces the time to search for the bug during future development.

## Reproduce:
```shell
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.json.junit.JSONObjectTest#valueToString
``` 

