### PR TITLE
fix: flakiness in org.json.junit.XMLTest#testIndentComplicatedJsonObjectWithArrayAndWithConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ JSON in Java [package org.json]
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.json/json.svg)](https://mvnrepository.com/artifact/org.json/json)
 
-**[Click here if you just want the latest release jar file.](https://search.maven.org/remotecontent?filepath=org/json/json/20230618/json-20230618.jar)**
+**[Click here if you just want the latest release jar file.](https://search.maven.org/remotecontent?filepath=org/json/json/20231013/json-20231013.jar)**
 
 
 # Overview

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.jayway.jsonpath:json-path:2.1.0'
     testImplementation 'org.mockito:mockito-core:4.2.0'
 }

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -5,6 +5,8 @@ and artifactId "json". For example:
 [https://search.maven.org/search?q=g:org.json%20AND%20a:json&core=gav](https://search.maven.org/search?q=g:org.json%20AND%20a:json&core=gav)
 
 ~~~
+20231013    First release with minimum Java version 1.8. Recent commits, including fixes for CVE-2023-5072.
+
 20230618    Final release with Java 1.6 compatibility. Future releases will require Java 1.8 or greater.
 
 20230227    Fix for CVE-2022-45688 and recent commits

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -160,34 +160,16 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.moditect</groupId>
-                <artifactId>moditect-maven-plugin</artifactId>
-                <version>1.0.0.Final</version>
-                <executions>
-                    <execution>
-                        <id>add-module-infos</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>add-module-info</goal>
-                        </goals>
-                        <configuration>
-                            <jvmVersion>9</jvmVersion>
-                            <module>
-                                <moduleInfo>
-                                    <name>org.json</name>
-                                    <exports>
-                                        org.json;
-                                    </exports>
-                                </moduleInfo>
-                            </module>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.json</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.json</groupId>
     <artifactId>json</artifactId>
-    <version>20230618</version>
+    <version>20231013</version>
     <packaging>bundle</packaging>
 
     <name>JSON in Java</name>
@@ -15,7 +15,7 @@
         It also includes the capability to convert between JSON and XML, HTTP
         headers, Cookies, and CDL.
 
-        This is a reference implementation. There is a large number of JSON packages
+        This is a reference implementation. There are a large number of JSON packages
         in Java. Perhaps someday the Java community will standardize on one. Until
         then, choose carefully.
     </description>

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -924,30 +924,57 @@ public class JSONArray implements Iterable<Object> {
     }
 
     /**
-     * Get the optional JSONArray associated with an index.
+     * Get the optional JSONArray associated with an index. Null is returned if
+     * there is no value at that index or if the value is not a JSONArray.
      *
      * @param index
-     *            subscript
-     * @return A JSONArray value, or null if the index has no value, or if the
-     *         value is not a JSONArray.
+     *            The index must be between 0 and length() - 1.
+     * @return A JSONArray value.
      */
     public JSONArray optJSONArray(int index) {
-        Object o = this.opt(index);
-        return o instanceof JSONArray ? (JSONArray) o : null;
+        return this.optJSONArray(index, null);
+    }
+
+    /**
+     * Get the optional JSONArray associated with an index. The defaultValue is returned if
+     * there is no value at that index or if the value is not a JSONArray.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default.
+     * @return A JSONArray value.
+     */
+    public JSONArray optJSONArray(int index, JSONArray defaultValue) {
+        Object object = this.opt(index);
+        return object instanceof JSONArray ? (JSONArray) object : defaultValue;
     }
 
     /**
      * Get the optional JSONObject associated with an index. Null is returned if
-     * the key is not found, or null if the index has no value, or if the value
-     * is not a JSONObject.
+     * there is no value at that index or if the value is not a JSONObject.
      *
      * @param index
      *            The index must be between 0 and length() - 1.
      * @return A JSONObject value.
      */
     public JSONObject optJSONObject(int index) {
-        Object o = this.opt(index);
-        return o instanceof JSONObject ? (JSONObject) o : null;
+        return this.optJSONObject(index, null);
+    }
+
+    /**
+     * Get the optional JSONObject associated with an index. The defaultValue is returned if
+     * there is no value at that index or if the value is not a JSONObject.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default.
+     * @return A JSONObject value.
+     */
+    public JSONObject optJSONObject(int index, JSONObject defaultValue) {
+        Object object = this.opt(index);
+        return object instanceof JSONObject ? (JSONObject) object : defaultValue;
     }
 
     /**

--- a/src/main/java/org/json/JSONArray.java
+++ b/src/main/java/org/json/JSONArray.java
@@ -1646,9 +1646,7 @@ public class JSONArray implements Iterable<Object> {
     @SuppressWarnings("resource")
     public String toString(int indentFactor) throws JSONException {
         StringWriter sw = new StringWriter();
-        synchronized (sw.getBuffer()) {
-            return this.write(sw, indentFactor, 0).toString();
-        }
+        return this.write(sw, indentFactor, 0).toString();
     }
 
     /**

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -208,22 +208,14 @@ public class JSONObject {
             throw x.syntaxError("A JSONObject text must begin with '{'");
         }
         for (;;) {
-            char prev = x.getPrevious();
             c = x.nextClean();
             switch (c) {
             case 0:
                 throw x.syntaxError("A JSONObject text must end with '}'");
             case '}':
                 return;
-            case '{':
-            case '[':
-                if(prev=='{') {
-                    throw x.syntaxError("A JSON Object can not directly nest another JSON Object or JSON Array.");
-                }
-                // fall through
             default:
-                x.back();
-                key = x.nextValue().toString();
+                key = x.nextSimpleValue(c).toString();
             }
 
             // The key is followed by ':'.
@@ -1712,12 +1704,12 @@ public class JSONObject {
                         final Object result = method.invoke(bean);
                         if (result != null) {
                             // check cyclic dependency and throw error if needed
-                            // the wrap and populateMap combination method is 
+                            // the wrap and populateMap combination method is
                             // itself DFS recursive
                             if (objectsRecord.contains(result)) {
                                 throw recursivelyDefinedObjectException(key);
                             }
-                            
+
                             objectsRecord.add(result);
 
                             this.map.put(key, wrap(result, objectsRecord));
@@ -1726,7 +1718,7 @@ public class JSONObject {
 
                             // we don't use the result anywhere outside of wrap
                             // if it's a resource we should be sure to close it
-                            // after calling toString 
+                            // after calling toString
                             if (result instanceof Closeable) {
                                 try {
                                     ((Closeable) result).close();

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -1512,8 +1512,22 @@ public class JSONObject {
      * @return A JSONArray which is the value.
      */
     public JSONArray optJSONArray(String key) {
-        Object o = this.opt(key);
-        return o instanceof JSONArray ? (JSONArray) o : null;
+        return this.optJSONArray(key, null);
+    }
+
+    /**
+     * Get an optional JSONArray associated with a key, or the default if there
+     * is no such key, or if its value is not a JSONArray.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return A JSONArray which is the value.
+     */
+    public JSONArray optJSONArray(String key, JSONArray defaultValue) {
+        Object object = this.opt(key);
+        return object instanceof JSONArray ? (JSONArray) object : defaultValue;
     }
 
     /**

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -283,6 +283,7 @@ public class JSONObject {
         	    }
                 final Object value = e.getValue();
                 if (value != null) {
+                    testValidity(value);
                     this.map.put(String.valueOf(e.getKey()), wrap(value));
                 }
             }
@@ -346,6 +347,8 @@ public class JSONObject {
      * @param bean
      *            An object that has getter methods that should be used to make
      *            a JSONObject.
+     * @throws JSONException
+     *            If a getter returned a non-finite number.
      */
     public JSONObject(Object bean) {
         this();
@@ -1691,6 +1694,8 @@ public class JSONObject {
      *
      * @param bean
      *            the bean
+     * @throws JSONException
+     *            If a getter returned a non-finite number.
      */
     private void populateMap(Object bean) {
         populateMap(bean, Collections.newSetFromMap(new IdentityHashMap<Object, Boolean>()));
@@ -1726,6 +1731,7 @@ public class JSONObject {
 
                             objectsRecord.add(result);
 
+                            testValidity(result);
                             this.map.put(key, wrap(result, objectsRecord));
 
                             objectsRecord.remove(result);

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -2379,12 +2379,13 @@ public class JSONObject {
      * returns for this function are BigDecimal, Double, BigInteger, Long, and Integer.
      * When a Double is returned, it should always be a valid Double and not NaN or +-infinity.
      *
-     * @param val value to convert
+     * @param input value to convert
      * @return Number representation of the value.
      * @throws NumberFormatException thrown if the value is not a valid number. A public
      *      caller should catch this and wrap it in a {@link JSONException} if applicable.
      */
-    protected static Number stringToNumber(final String val) throws NumberFormatException {
+    protected static Number stringToNumber(final String input) throws NumberFormatException {
+        String val = input;
         char initial = val.charAt(0);
         if ((initial >= '0' && initial <= '9') || initial == '-') {
             // decimal representation
@@ -2411,6 +2412,8 @@ public class JSONObject {
                     }
                 }
             }
+            val = removeLeadingZerosOfNumber(input);
+            initial = val.charAt(0);
             // block items like 00 01 etc. Java number parsers treat these as Octal.
             if(initial == '0' && val.length() > 1) {
                 char at1 = val.charAt(1);
@@ -2885,5 +2888,34 @@ public class JSONObject {
         return new JSONException(
             "JavaBean object contains recursively defined member variable of key " + quote(key)
         );
+    }
+
+    /**
+     * For a prospective number, remove the leading zeros
+     * @param value prospective number
+     * @return number without leading zeros
+     */
+    private static String removeLeadingZerosOfNumber(String value){
+        char[] chars = value.toCharArray();
+        int leftMostUnsignedIndex = 0;
+        if (chars[0] == '-'){
+            leftMostUnsignedIndex = 1;
+        }
+        int firstNonZeroCharIndex = -1;
+        for (int i=leftMostUnsignedIndex;i<value.length();i++){
+            if (chars[i] != '0'){
+                firstNonZeroCharIndex = i;
+                break;
+            }
+        }
+        if (firstNonZeroCharIndex == -1){
+            return value;
+        }
+        StringBuilder result = new StringBuilder();
+        if (leftMostUnsignedIndex == 1){
+            result.append('-');
+        }
+        result.append(value.substring(firstNonZeroCharIndex));
+        return result.toString();
     }
 }

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -2416,17 +2416,16 @@ public class JSONObject {
                     try {
                         Double d = Double.valueOf(val);
                         if(d.isNaN() || d.isInfinite()) {
-                            throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                            throw new NumberFormatException("val ["+input+"] is not a valid number.");
                         }
                         return d;
                     } catch (NumberFormatException ignore) {
-                        throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                        throw new NumberFormatException("val ["+input+"] is not a valid number.");
                     }
                 }
             }
             val = removeLeadingZerosOfNumber(input);
             initial = val.charAt(0);
-            // block items like 00 01 etc. Java number parsers treat these as Octal.
             if(initial == '0' && val.length() > 1) {
                 char at1 = val.charAt(1);
                 if(at1 >= '0' && at1 <= '9') {
@@ -2934,10 +2933,12 @@ public class JSONObject {
         int counter = negativeFirstChar ? 1:0;
         while (counter < value.length()){
             if (value.charAt(counter) != '0'){
-                return String.format("%s%s", negativeFirstChar?'-':"",value.substring(counter));
+                if (negativeFirstChar) {return "-".concat(value.substring(counter));}
+                return value.substring(counter);
             }
             ++counter;
         }
-        return String.format("%s%s", negativeFirstChar?'-':"",'0');
+        if (negativeFirstChar) {return "-0";}
+        return "0";
     }
 }

--- a/src/main/java/org/json/JSONObject.java
+++ b/src/main/java/org/json/JSONObject.java
@@ -2191,13 +2191,11 @@ public class JSONObject {
     @SuppressWarnings("resource")
     public static String quote(String string) {
         StringWriter sw = new StringWriter();
-        synchronized (sw.getBuffer()) {
-            try {
-                return quote(string, sw).toString();
-            } catch (IOException ignored) {
-                // will never happen - we are writing to a string writer
-                return "";
-            }
+        try {
+            return quote(string, sw).toString();
+        } catch (IOException ignored) {
+            // will never happen - we are writing to a string writer
+            return "";
         }
     }
 
@@ -2584,9 +2582,7 @@ public class JSONObject {
     @SuppressWarnings("resource")
     public String toString(int indentFactor) throws JSONException {
         StringWriter w = new StringWriter();
-        synchronized (w.getBuffer()) {
-            return this.write(w, indentFactor, 0).toString();
-        }
+        return this.write(w, indentFactor, 0).toString();
     }
 
     /**

--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -428,10 +428,6 @@ public class JSONTokener {
         case '"':
         case '\'':
             return this.nextString(c);
-        case '{':
-            throw syntaxError("Nested object not expected here.");
-        case '[':
-            throw syntaxError("Nested array not expected here.");
         }
 
         /*

--- a/src/main/java/org/json/JSONTokener.java
+++ b/src/main/java/org/json/JSONTokener.java
@@ -402,12 +402,7 @@ public class JSONTokener {
      */
     public Object nextValue() throws JSONException {
         char c = this.nextClean();
-        String string;
-
         switch (c) {
-        case '"':
-        case '\'':
-            return this.nextString(c);
         case '{':
             this.back();
             try {
@@ -422,6 +417,21 @@ public class JSONTokener {
             } catch (StackOverflowError e) {
                 throw new JSONException("JSON Array or Object depth too large to process.", e);
             }
+        }
+        return nextSimpleValue(c);
+    }
+
+    Object nextSimpleValue(char c) {
+        String string;
+
+        switch (c) {
+        case '"':
+        case '\'':
+            return this.nextString(c);
+        case '{':
+            throw syntaxError("Nested object not expected here.");
+        case '[':
+            throw syntaxError("Nested array not expected here.");
         }
 
         /*

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -118,7 +118,7 @@ public class JSONArrayTest {
      * Expects a JSONException.
      */
     @Test
-    public void emptStr() {
+    public void emptyStr() {
         String str = "";
         try {
             assertNull("Should throw an exception", new JSONArray(str));
@@ -458,6 +458,20 @@ public class JSONArrayTest {
                     "JSONArray[5] is not a String (class java.math.BigDecimal : 0.002345).",e.getMessage());
         }
         Util.checkJSONArrayMaps(jsonArray);
+    }
+
+    /**
+     * The JSON parser is permissive of unambiguous unquoted keys and values.
+     * Such JSON text should be allowed, even if it does not strictly conform
+     * to the spec. However, after being parsed, toString() should emit strictly
+     * conforming JSON text.  
+     */
+    @Test
+    public void unquotedText() {
+        String str = "[value1, something!, (parens), foo@bar.com, 23, 23+45]";
+        JSONArray jsonArray = new JSONArray(str);
+        List<Object> expected = Arrays.asList("value1", "something!", "(parens)", "foo@bar.com", 23, "23+45");
+        assertEquals(expected, jsonArray.toList());
     }
 
     /**

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -595,13 +595,17 @@ public class JSONArrayTest {
 
         JSONArray nestedJsonArray = jsonArray.optJSONArray(9);
         assertTrue("Array opt JSONArray", nestedJsonArray != null);
-        assertTrue("Array opt JSONArray default", 
+        assertTrue("Array opt JSONArray null",
                 null == jsonArray.optJSONArray(99));
+        assertTrue("Array opt JSONArray default",
+                "value".equals(jsonArray.optJSONArray(99, new JSONArray("[\"value\"]")).getString(0)));
 
         JSONObject nestedJsonObject = jsonArray.optJSONObject(10);
         assertTrue("Array opt JSONObject", nestedJsonObject != null);
-        assertTrue("Array opt JSONObject default", 
+        assertTrue("Array opt JSONObject null",
                 null == jsonArray.optJSONObject(99));
+        assertTrue("Array opt JSONObject default",
+                "value".equals(jsonArray.optJSONObject(99, new JSONObject("{\"key\":\"value\"}")).getString("key")));
 
         assertTrue("Array opt long",
                 0 == jsonArray.optLong(11));

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -1369,7 +1369,7 @@ public class JSONArrayTest {
     @Test(expected = JSONException.class)
     public void issue654StackOverflowInputWellFormed() {
         //String input = new String(java.util.Base64.getDecoder().decode(base64Bytes));
-        final InputStream resourceAsStream = JSONObjectTest.class.getClassLoader().getResourceAsStream("Issue654WellFormedArray.json");
+        final InputStream resourceAsStream = JSONArrayTest.class.getClassLoader().getResourceAsStream("Issue654WellFormedArray.json");
         JSONTokener tokener = new JSONTokener(resourceAsStream);
         JSONArray json_input = new JSONArray(tokener);
         assertNotNull(json_input);

--- a/src/test/java/org/json/junit/JSONObjectDecimalTest.java
+++ b/src/test/java/org/json/junit/JSONObjectDecimalTest.java
@@ -1,0 +1,100 @@
+package org.json.junit;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public class JSONObjectDecimalTest {
+
+    @Test
+    public void shouldParseDecimalNumberThatStartsWithDecimalPoint(){
+        JSONObject jsonObject = new JSONObject("{value:0.50}");
+        assertEquals("Float not recognized", 0.5f, jsonObject.getFloat("value"), 0.0f);
+        assertEquals("Float not recognized", 0.5f, jsonObject.optFloat("value"), 0.0f);
+        assertEquals("Float not recognized", 0.5f, jsonObject.optFloatObject("value"), 0.0f);
+        assertEquals("Double not recognized", 0.5d, jsonObject.optDouble("value"), 0.0f);
+        assertEquals("Double not recognized", 0.5d, jsonObject.optDoubleObject("value"), 0.0f);
+        assertEquals("Double not recognized", 0.5d, jsonObject.getDouble("value"), 0.0f);
+        assertEquals("Long not recognized", 0, jsonObject.optLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.getLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.optLongObject("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.getInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optIntegerObject("value"), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").intValue(), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").longValue(), 0);
+        assertEquals("BigDecimal not recognized", 0, BigDecimal.valueOf(.5).compareTo(jsonObject.getBigDecimal("value")));
+        assertEquals("BigInteger not recognized",0, BigInteger.valueOf(0).compareTo(jsonObject.getBigInteger("value")));
+    }
+
+
+
+    @Test
+    public void shouldParseNegativeDecimalNumberThatStartsWithDecimalPoint(){
+        JSONObject jsonObject = new JSONObject("{value:-.50}");
+        assertEquals("Float not recognized", -0.5f, jsonObject.getFloat("value"), 0.0f);
+        assertEquals("Float not recognized", -0.5f, jsonObject.optFloat("value"), 0.0f);
+        assertEquals("Float not recognized", -0.5f, jsonObject.optFloatObject("value"), 0.0f);
+        assertEquals("Double not recognized", -0.5d, jsonObject.optDouble("value"), 0.0f);
+        assertEquals("Double not recognized", -0.5d, jsonObject.optDoubleObject("value"), 0.0f);
+        assertEquals("Double not recognized", -0.5d, jsonObject.getDouble("value"), 0.0f);
+        assertEquals("Long not recognized", 0, jsonObject.optLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.getLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.optLongObject("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.getInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optIntegerObject("value"), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").intValue(), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").longValue(), 0);
+        assertEquals("BigDecimal not recognized", 0, BigDecimal.valueOf(-.5).compareTo(jsonObject.getBigDecimal("value")));
+        assertEquals("BigInteger not recognized",0, BigInteger.valueOf(0).compareTo(jsonObject.getBigInteger("value")));
+    }
+
+    @Test
+    public void shouldParseDecimalNumberThatHasZeroBeforeWithDecimalPoint(){
+        JSONObject jsonObject = new JSONObject("{value:00.050}");
+        assertEquals("Float not recognized", 0.05f, jsonObject.getFloat("value"), 0.0f);
+        assertEquals("Float not recognized", 0.05f, jsonObject.optFloat("value"), 0.0f);
+        assertEquals("Float not recognized", 0.05f, jsonObject.optFloatObject("value"), 0.0f);
+        assertEquals("Double not recognized", 0.05d, jsonObject.optDouble("value"), 0.0f);
+        assertEquals("Double not recognized", 0.05d, jsonObject.optDoubleObject("value"), 0.0f);
+        assertEquals("Double not recognized", 0.05d, jsonObject.getDouble("value"), 0.0f);
+        assertEquals("Long not recognized", 0, jsonObject.optLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.getLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.optLongObject("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.getInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optIntegerObject("value"), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").intValue(), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").longValue(), 0);
+        assertEquals("BigDecimal not recognized", 0, BigDecimal.valueOf(.05).compareTo(jsonObject.getBigDecimal("value")));
+        assertEquals("BigInteger not recognized",0, BigInteger.valueOf(0).compareTo(jsonObject.getBigInteger("value")));
+    }
+
+    @Test
+    public void shouldParseNegativeDecimalNumberThatHasZeroBeforeWithDecimalPoint(){
+        JSONObject jsonObject = new JSONObject("{value:-00.050}");
+        assertEquals("Float not recognized", -0.05f, jsonObject.getFloat("value"), 0.0f);
+        assertEquals("Float not recognized", -0.05f, jsonObject.optFloat("value"), 0.0f);
+        assertEquals("Float not recognized", -0.05f, jsonObject.optFloatObject("value"), 0.0f);
+        assertEquals("Double not recognized", -0.05d, jsonObject.optDouble("value"), 0.0f);
+        assertEquals("Double not recognized", -0.05d, jsonObject.optDoubleObject("value"), 0.0f);
+        assertEquals("Double not recognized", -0.05d, jsonObject.getDouble("value"), 0.0f);
+        assertEquals("Long not recognized", 0, jsonObject.optLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.getLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.optLongObject("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.getInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optIntegerObject("value"), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").intValue(), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").longValue(), 0);
+        assertEquals("BigDecimal not recognized", 0, BigDecimal.valueOf(-.05).compareTo(jsonObject.getBigDecimal("value")));
+        assertEquals("BigInteger not recognized",0, BigInteger.valueOf(0).compareTo(jsonObject.getBigInteger("value")));
+    }
+
+
+}

--- a/src/test/java/org/json/junit/JSONObjectNumberTest.java
+++ b/src/test/java/org/json/junit/JSONObjectNumberTest.java
@@ -23,7 +23,10 @@ public class JSONObjectNumberTest {
     @Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            {"{value:50}", 1},
+            {"{value:0050}", 1},
+            {"{value:0050.0000}", 1},
+            {"{value:-0050}", -1},
+            {"{value:-0050.0000}", -1},
             {"{value:50.0}", 1},
             {"{value:5e1}", 1},
             {"{value:5E1}", 1},
@@ -32,6 +35,7 @@ public class JSONObjectNumberTest {
             {"{value:-50}", -1},
             {"{value:-50.0}", -1},
             {"{value:-5e1}", -1},
+            {"{value:-0005e1}", -1},
             {"{value:-5E1}", -1},
             {"{value:-5e1}", -1},
             {"{value:'-50'}", -1}

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -1972,7 +1973,7 @@ public class JSONObjectTest {
     @Test
     public void jsonObjectToStringSuppressWarningOnCastToMap() {
         JSONObject jsonObject = new JSONObject();
-        Map<String, String> map = new HashMap();
+        Map<String, String> map = new HashMap<>();
         map.put("abc", "def");
         jsonObject.put("key", map);
 
@@ -3283,7 +3284,7 @@ public class JSONObjectTest {
     @SuppressWarnings("boxing")
     @Test
     public void testGenericBean() {
-        GenericBean<Integer> bean = new GenericBean(42);
+        GenericBean<Integer> bean = new GenericBean<>(42);
         final JSONObject jo = new JSONObject(bean);
         assertEquals(jo.keySet().toString(), 8, jo.length());
         assertEquals(42, jo.get("genericValue"));
@@ -3626,5 +3627,26 @@ public class JSONObjectTest {
                 })
                 .put("b", 2);
         assertFalse(jo1.similar(jo3));
+    }
+
+    private static final Number[] NON_FINITE_NUMBERS = { Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NaN,
+            Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NaN };
+
+    @Test
+    public void issue713MapConstructorWithNonFiniteNumbers() {
+        for (Number nonFinite : NON_FINITE_NUMBERS) {
+            Map<String, Number> map = new HashMap<>();
+            map.put("a", nonFinite);
+
+            assertThrows(JSONException.class, () -> new JSONObject(map));
+        }
+    }
+
+    @Test
+    public void issue713BeanConstructorWithNonFiniteNumbers() {
+        for (Number nonFinite : NON_FINITE_NUMBERS) {
+            GenericBean<Number> bean = new GenericBean<>(nonFinite);
+            assertThrows(JSONException.class, () -> new JSONObject(bean));
+        }
     }
 }

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -1063,12 +1063,16 @@ public class JSONObjectTest {
                 "\"tooManyZeros\":00,"+
                 "\"negativeInfinite\":-Infinity,"+
                 "\"negativeNaN\":-NaN,"+
+                "\"negativeNaNWithLeadingZeros\":-00NaN,"+
                 "\"negativeFraction\":-.01,"+
                 "\"tooManyZerosFraction\":00.001,"+
                 "\"negativeHexFloat\":-0x1.fffp1,"+
                 "\"hexFloat\":0x1.0P-1074,"+
                 "\"floatIdentifier\":0.1f,"+
-                "\"doubleIdentifier\":0.1d"+
+                "\"doubleIdentifier\":0.1d,"+
+                "\"integerWithLeadingZeros\":000900,"+
+                "\"integerWithAllZeros\":00000,"+
+                "\"compositeWithLeadingZeros\":00800.90d"+
             "}";
         JSONObject jsonObject = new JSONObject(str);
         Object obj;
@@ -1085,10 +1089,17 @@ public class JSONObjectTest {
         obj = jsonObject.get("negativeNaN");
         assertTrue( "negativeNaN currently evaluates to string",
                 obj.equals("-NaN"));
+        obj = jsonObject.get("negativeNaNWithLeadingZeros");
+        assertTrue( "negativeNaNWithLeadingZeros currently evaluates to string",
+                obj.equals("-00NaN"));
         assertTrue( "negativeFraction currently evaluates to double -0.01",
                 jsonObject.get( "negativeFraction" ).equals(BigDecimal.valueOf(-0.01)));
         assertTrue( "tooManyZerosFraction currently evaluates to double 0.001",
                 jsonObject.get( "tooManyZerosFraction" ).equals(BigDecimal.valueOf(0.001)));
+        assertTrue( "tooManyZerosFraction currently evaluates to double 0.001",
+                jsonObject.getLong( "tooManyZerosFraction" )==0);
+        assertTrue( "tooManyZerosFraction currently evaluates to double 0.001",
+                jsonObject.optLong( "tooManyZerosFraction" )==0);
         assertTrue( "negativeHexFloat currently evaluates to double -3.99951171875",
                 jsonObject.get( "negativeHexFloat" ).equals(Double.valueOf(-3.99951171875)));
         assertTrue("hexFloat currently evaluates to double 4.9E-324",
@@ -1097,6 +1108,28 @@ public class JSONObjectTest {
                 jsonObject.get("floatIdentifier").equals(Double.valueOf(0.1)));
         assertTrue("doubleIdentifier currently evaluates to double 0.1",
                 jsonObject.get("doubleIdentifier").equals(Double.valueOf(0.1)));
+        assertTrue("Integer does not evaluate to 900",
+                jsonObject.get("integerWithLeadingZeros").equals(900));
+        assertTrue("Integer does not evaluate to 900",
+                jsonObject.getInt("integerWithLeadingZeros")==900);
+        assertTrue("Integer does not evaluate to 900",
+                jsonObject.optInt("integerWithLeadingZeros")==900);
+        assertTrue("Integer does not evaluate to 0",
+                jsonObject.get("integerWithAllZeros").equals("00000"));
+        assertTrue("Integer does not evaluate to 0",
+                jsonObject.getInt("integerWithAllZeros")==0);
+        assertTrue("Integer does not evaluate to 0",
+                jsonObject.optInt("integerWithAllZeros")==0);
+        assertTrue("Double does not evaluate to 800.90",
+                jsonObject.get("compositeWithLeadingZeros").equals(800.90));
+        assertTrue("Double does not evaluate to 800.90",
+                jsonObject.getDouble("compositeWithLeadingZeros")==800.9d);
+        assertTrue("Integer does not evaluate to 800",
+                jsonObject.optInt("compositeWithLeadingZeros")==800);
+        assertTrue("Long does not evaluate to 800.90",
+                jsonObject.getLong("compositeWithLeadingZeros")==800);
+        assertTrue("Long does not evaluate to 800.90",
+                jsonObject.optLong("compositeWithLeadingZeros")==800);
         Util.checkJSONObjectMaps(jsonObject);
     }
 

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -4,6 +4,7 @@ package org.json.junit;
 Public Domain.
 */
 
+import static java.lang.Double.NaN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -782,7 +783,7 @@ public class JSONObjectTest {
         jsonObject.accumulate("myArray", -23.45e7);
         // include an unsupported object for coverage
         try {
-            jsonObject.accumulate("myArray", Double.NaN);
+            jsonObject.accumulate("myArray", NaN);
             fail("Expected exception");
         } catch (JSONException ignored) {}
 
@@ -814,7 +815,7 @@ public class JSONObjectTest {
         jsonObject.append("myArray", -23.45e7);
         // include an unsupported object for coverage
         try {
-            jsonObject.append("myArray", Double.NaN);
+            jsonObject.append("myArray", NaN);
             fail("Expected exception");
         } catch (JSONException ignored) {}
 
@@ -839,7 +840,7 @@ public class JSONObjectTest {
     public void jsonObjectDoubleToString() {
         String [] expectedStrs = {"1", "1", "-23.4", "-2.345E68", "null", "null" };
         Double [] doubles = { 1.0, 00001.00000, -23.4, -23.45e67, 
-                Double.NaN, Double.NEGATIVE_INFINITY }; 
+                NaN, Double.NEGATIVE_INFINITY };
         for (int i = 0; i < expectedStrs.length; ++i) {
             String actualStr = JSONObject.doubleToString(doubles[i]);
             assertTrue("value expected ["+expectedStrs[i]+
@@ -894,11 +895,11 @@ public class JSONObjectTest {
         assertTrue("opt doubleKey should be double", 
                 jsonObject.optDouble("doubleKey") == -23.45e7);
         assertTrue("opt doubleKey with Default should be double", 
-                jsonObject.optDouble("doubleStrKey", Double.NaN) == 1);
+                jsonObject.optDouble("doubleStrKey", NaN) == 1);
         assertTrue("opt doubleKey should be Double",
                 Double.valueOf(-23.45e7).equals(jsonObject.optDoubleObject("doubleKey")));
         assertTrue("opt doubleKey with Default should be Double",
-                Double.valueOf(1).equals(jsonObject.optDoubleObject("doubleStrKey", Double.NaN)));
+                Double.valueOf(1).equals(jsonObject.optDoubleObject("doubleStrKey", NaN)));
         assertTrue("opt negZeroKey should be a Double", 
                 jsonObject.opt("negZeroKey") instanceof Double);
         assertTrue("get negZeroKey should be a Double", 
@@ -1071,9 +1072,14 @@ public class JSONObjectTest {
                 "\"hexFloat\":0x1.0P-1074,"+
                 "\"floatIdentifier\":0.1f,"+
                 "\"doubleIdentifier\":0.1d,"+
+                "\"doubleIdentifierWithMultipleLeadingZerosBeforeDecimal\":0000000.1d,"+
+                "\"negativeDoubleIdentifierWithMultipleLeadingZerosBeforeDecimal\":-0000000.1d,"+
+                "\"doubleIdentifierWithMultipleLeadingZerosAfterDecimal\":0000000.0001d,"+
+                "\"negativeDoubleIdentifierWithMultipleLeadingZerosAfterDecimal\":-0000000.0001d,"+
                 "\"integerWithLeadingZeros\":000900,"+
                 "\"integerWithAllZeros\":00000,"+
-                "\"compositeWithLeadingZeros\":00800.90d"+
+                "\"compositeWithLeadingZeros\":00800.90d,"+
+                "\"decimalPositiveWithoutNumberBeforeDecimalPoint\":.90,"+
             "}";
         JSONObject jsonObject = new JSONObject(str);
         Object obj;
@@ -1083,7 +1089,7 @@ public class JSONObjectTest {
         assertTrue("hexNumber currently evaluates to string",
                 obj.equals("-0x123"));
         assertTrue( "tooManyZeros currently evaluates to string",
-                jsonObject.get( "tooManyZeros" ).equals("00"));
+                jsonObject.get( "tooManyZeros" ).equals(0));
         obj = jsonObject.get("negativeInfinite");
         assertTrue( "negativeInfinite currently evaluates to string",
                 obj.equals("-Infinity"));
@@ -1109,6 +1115,16 @@ public class JSONObjectTest {
                 jsonObject.get("floatIdentifier").equals(Double.valueOf(0.1)));
         assertTrue("doubleIdentifier currently evaluates to double 0.1",
                 jsonObject.get("doubleIdentifier").equals(Double.valueOf(0.1)));
+        assertTrue("doubleIdentifierWithMultipleLeadingZerosBeforeDecimal currently evaluates to double 0.1",
+                jsonObject.get("doubleIdentifierWithMultipleLeadingZerosBeforeDecimal").equals(Double.valueOf(0.1)));
+        assertTrue("negativeDoubleIdentifierWithMultipleLeadingZerosBeforeDecimal currently evaluates to double -0.1",
+                jsonObject.get("negativeDoubleIdentifierWithMultipleLeadingZerosBeforeDecimal").equals(Double.valueOf(-0.1)));
+        assertTrue("doubleIdentifierWithMultipleLeadingZerosAfterDecimal currently evaluates to double 0.0001",
+                jsonObject.get("doubleIdentifierWithMultipleLeadingZerosAfterDecimal").equals(Double.valueOf(0.0001)));
+        assertTrue("doubleIdentifierWithMultipleLeadingZerosAfterDecimal currently evaluates to double 0.0001",
+                jsonObject.get("doubleIdentifierWithMultipleLeadingZerosAfterDecimal").equals(Double.valueOf(0.0001)));
+        assertTrue("negativeDoubleIdentifierWithMultipleLeadingZerosAfterDecimal currently evaluates to double -0.0001",
+                jsonObject.get("negativeDoubleIdentifierWithMultipleLeadingZerosAfterDecimal").equals(Double.valueOf(-0.0001)));
         assertTrue("Integer does not evaluate to 900",
                 jsonObject.get("integerWithLeadingZeros").equals(900));
         assertTrue("Integer does not evaluate to 900",
@@ -1116,7 +1132,7 @@ public class JSONObjectTest {
         assertTrue("Integer does not evaluate to 900",
                 jsonObject.optInt("integerWithLeadingZeros")==900);
         assertTrue("Integer does not evaluate to 0",
-                jsonObject.get("integerWithAllZeros").equals("00000"));
+                jsonObject.get("integerWithAllZeros").equals(0));
         assertTrue("Integer does not evaluate to 0",
                 jsonObject.getInt("integerWithAllZeros")==0);
         assertTrue("Integer does not evaluate to 0",
@@ -1131,6 +1147,21 @@ public class JSONObjectTest {
                 jsonObject.getLong("compositeWithLeadingZeros")==800);
         assertTrue("Long does not evaluate to 800.90",
                 jsonObject.optLong("compositeWithLeadingZeros")==800);
+        assertEquals("Get long of decimalPositiveWithoutNumberBeforeDecimalPoint does not match",
+                0.9d,jsonObject.getDouble("decimalPositiveWithoutNumberBeforeDecimalPoint"),  0.0d);
+        assertEquals("Get long of decimalPositiveWithoutNumberBeforeDecimalPoint does not match",
+                0.9d,jsonObject.optDouble("decimalPositiveWithoutNumberBeforeDecimalPoint"),  0.0d);
+        assertEquals("Get long of decimalPositiveWithoutNumberBeforeDecimalPoint does not match",
+                0.0d,jsonObject.optLong("decimalPositiveWithoutNumberBeforeDecimalPoint"),  0.0d);
+
+        assertEquals("Get long of doubleIdentifierWithMultipleLeadingZerosAfterDecimal does not match",
+                0.0001d,jsonObject.getDouble("doubleIdentifierWithMultipleLeadingZerosAfterDecimal"),  0.0d);
+        assertEquals("Get long of doubleIdentifierWithMultipleLeadingZerosAfterDecimal does not match",
+                0.0001d,jsonObject.optDouble("doubleIdentifierWithMultipleLeadingZerosAfterDecimal"),  0.0d);
+        assertEquals("Get long of doubleIdentifierWithMultipleLeadingZerosAfterDecimal does not match",
+                0.0d, jsonObject.getLong("doubleIdentifierWithMultipleLeadingZerosAfterDecimal") , 0.0d);
+        assertEquals("Get long of doubleIdentifierWithMultipleLeadingZerosAfterDecimal does not match",
+                0.0d,jsonObject.optLong("doubleIdentifierWithMultipleLeadingZerosAfterDecimal"),  0.0d);
         Util.checkJSONObjectMaps(jsonObject);
     }
 
@@ -2361,7 +2392,7 @@ public class JSONObjectTest {
         }
         try {
             // test validity of invalid double 
-            JSONObject.testValidity(Double.NaN);
+            JSONObject.testValidity(NaN);
             fail("Expected an exception");
         } catch (JSONException e) { 
             assertTrue("", true);

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -2225,6 +2225,24 @@ public class JSONObjectTest {
                     e.getMessage());
         }
         try {
+            // key is a nested map
+            String str = "{{\"foo\": \"bar\"}: \"baz\"}";
+            assertNull("Expected an exception",new JSONObject(str));
+        } catch (JSONException e) {
+            assertEquals("Expecting an exception message",
+                "Nested object not expected here. at 2 [character 3 line 1]",
+                e.getMessage());
+        }
+        try {
+            // key is a nested array containing a map
+            String str = "{\"a\": 1, [{\"foo\": \"bar\"}]: \"baz\"}";
+            assertNull("Expected an exception",new JSONObject(str));
+        } catch (JSONException e) {
+            assertEquals("Expecting an exception message",
+                "Nested array not expected here. at 10 [character 11 line 1]",
+                e.getMessage());
+        }
+        try {
             // \0 after ,
             String str = "{\"myKey\":true, \0\"myOtherKey\":false}";
             assertNull("Expected an exception",new JSONObject(str));

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -2510,6 +2510,8 @@ public class JSONObjectTest {
                 MyEnum.VAL1.equals(jsonObject.optEnum(MyEnum.class, "myKey", MyEnum.VAL1)));
         assertTrue("optJSONArray() should return null ",
                 null==jsonObject.optJSONArray("myKey"));
+        assertTrue("optJSONArray() should return default JSONArray",
+                "value".equals(jsonObject.optJSONArray("myKey", new JSONArray("[\"value\"]")).getString(0)));
         assertTrue("optJSONObject() should return default JSONObject ",
                 jsonObject.optJSONObject("myKey", new JSONObject("{\"testKey\":\"testValue\"}")).getString("testKey").equals("testValue"));
         assertTrue("optLong() should return default long",
@@ -2555,6 +2557,8 @@ public class JSONObjectTest {
                  Integer.valueOf(42).equals(jsonObject.optIntegerObject("myKey", 42)));
          assertTrue("optEnum() should return default Enum",
                  MyEnum.VAL1.equals(jsonObject.optEnum(MyEnum.class, "myKey", MyEnum.VAL1)));
+         assertTrue("optJSONArray() should return default JSONArray",
+                 "value".equals(jsonObject.optJSONArray("myKey", new JSONArray("[\"value\"]")).getString(0)));
          assertTrue("optJSONArray() should return null ",
                  null==jsonObject.optJSONArray("myKey"));
          assertTrue("optJSONObject() should return default JSONObject ",

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -3288,6 +3288,7 @@ public class JSONObjectTest {
      * Sample test case from https://github.com/stleary/JSON-java/issues/531
      * which verifies that no regression in double/BigDecimal support is present.
      */
+    @Test
     public void testObjectToBigDecimal() {  
         double value = 1412078745.01074;  
         Reader reader = new StringReader("[{\"value\": " + value + "}]");

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -2230,7 +2230,7 @@ public class JSONObjectTest {
             assertNull("Expected an exception",new JSONObject(str));
         } catch (JSONException e) {
             assertEquals("Expecting an exception message",
-                "Nested object not expected here. at 2 [character 3 line 1]",
+                "Missing value at 1 [character 2 line 1]",
                 e.getMessage());
         }
         try {
@@ -2239,7 +2239,7 @@ public class JSONObjectTest {
             assertNull("Expected an exception",new JSONObject(str));
         } catch (JSONException e) {
             assertEquals("Expecting an exception message",
-                "Nested array not expected here. at 10 [character 11 line 1]",
+                "Missing value at 9 [character 10 line 1]",
                 e.getMessage());
         }
         try {

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -205,13 +205,17 @@ public class JSONObjectTest {
      */
     @Test
     public void unquotedText() {
-        String str = "{key1:value1, key2:42}";
+        String str = "{key1:value1, key2:42, 1.2 : 3.4, -7e5 : something!}";
         JSONObject jsonObject = new JSONObject(str);
         String textStr = jsonObject.toString();
         assertTrue("expected key1", textStr.contains("\"key1\""));
         assertTrue("expected value1", textStr.contains("\"value1\""));
         assertTrue("expected key2", textStr.contains("\"key2\""));
         assertTrue("expected 42", textStr.contains("42"));
+        assertTrue("expected 1.2", textStr.contains("\"1.2\""));
+        assertTrue("expected 3.4", textStr.contains("3.4"));
+        assertTrue("expected -7E+5", textStr.contains("\"-7E+5\""));
+        assertTrue("expected something!", textStr.contains("\"something!\""));
         Util.checkJSONObjectMaps(jsonObject);
     }
     
@@ -2240,6 +2244,24 @@ public class JSONObjectTest {
         } catch (JSONException e) {
             assertEquals("Expecting an exception message",
                 "Missing value at 9 [character 10 line 1]",
+                e.getMessage());
+        }
+        try {
+            // key contains }
+            String str = "{foo}: 2}";
+            assertNull("Expected an exception",new JSONObject(str));
+        } catch (JSONException e) {
+            assertEquals("Expecting an exception message",
+                "Expected a ':' after a key at 5 [character 6 line 1]",
+                e.getMessage());
+        }
+        try {
+            // key contains ]
+            String str = "{foo]: 2}";
+            assertNull("Expected an exception",new JSONObject(str));
+        } catch (JSONException e) {
+            assertEquals("Expecting an exception message",
+                "Expected a ':' after a key at 5 [character 6 line 1]",
                 e.getMessage());
         }
         try {

--- a/src/test/java/org/json/junit/JsonNumberZeroTest.java
+++ b/src/test/java/org/json/junit/JsonNumberZeroTest.java
@@ -1,0 +1,55 @@
+package org.json.junit;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public class JsonNumberZeroTest {
+
+    @Test
+    public void shouldParseNegativeZeroValueWithMultipleZeroDigit(){
+        JSONObject jsonObject = new JSONObject("{value:-0000}");
+        assertEquals("Float not recognized", -0f, jsonObject.getFloat("value"), 0.0f);
+        assertEquals("Float not recognized", -0f, jsonObject.optFloat("value"), 0.0f);
+        assertEquals("Float not recognized", -0f, jsonObject.optFloatObject("value"), 0.0f);
+        assertEquals("Double not recognized", -0d, jsonObject.optDouble("value"), 0.0f);
+        assertEquals("Double not recognized", -0.0d, jsonObject.optDoubleObject("value"), 0.0f);
+        assertEquals("Double not recognized", -0.0d, jsonObject.getDouble("value"), 0.0f);
+        assertEquals("Long not recognized", 0, jsonObject.optLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.getLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.optLongObject("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.getInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optIntegerObject("value"), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").intValue(), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").longValue(), 0);
+        assertEquals("BigDecimal not recognized", 0, BigDecimal.valueOf(-0).compareTo(jsonObject.getBigDecimal("value")));
+        assertEquals("BigInteger not recognized",0, BigInteger.valueOf(0).compareTo(jsonObject.getBigInteger("value")));
+    }
+
+    @Test
+    public void shouldParseZeroValueWithMultipleZeroDigit(){
+        JSONObject jsonObject = new JSONObject("{value:0000}");
+        assertEquals("Float not recognized", 0f, jsonObject.getFloat("value"), 0.0f);
+        assertEquals("Float not recognized", 0f, jsonObject.optFloat("value"), 0.0f);
+        assertEquals("Float not recognized", 0f, jsonObject.optFloatObject("value"), 0.0f);
+        assertEquals("Double not recognized", 0d, jsonObject.optDouble("value"), 0.0f);
+        assertEquals("Double not recognized", 0.0d, jsonObject.optDoubleObject("value"), 0.0f);
+        assertEquals("Double not recognized", 0.0d, jsonObject.getDouble("value"), 0.0f);
+        assertEquals("Long not recognized", 0, jsonObject.optLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.getLong("value"), 0);
+        assertEquals("Long not recognized", 0, jsonObject.optLongObject("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.getInt("value"), 0);
+        assertEquals("Integer not recognized", 0, jsonObject.optIntegerObject("value"), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").intValue(), 0);
+        assertEquals("Number not recognized", 0, jsonObject.getNumber("value").longValue(), 0);
+        assertEquals("BigDecimal not recognized", 0, BigDecimal.valueOf(-0).compareTo(jsonObject.getBigDecimal("value")));
+        assertEquals("BigInteger not recognized",0, BigInteger.valueOf(0).compareTo(jsonObject.getBigInteger("value")));
+    }
+
+}

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1239,7 +1239,8 @@ public class XMLTest {
                     for (int numRead; (numRead = in.read(buffer, 0, buffer.length)) > 0; ) {
                         expected.append(buffer, 0, numRead);
                     }
-                    assertEquals(expected.toString(), actualString.replaceAll("\\n|\\r\\n", System.getProperty("line.separator")));
+                    assertEquals(expected.toString().replaceAll("\\n|\\r\\n", System.getProperty("line.separator")),
+                            actualString.replaceAll("\\n|\\r\\n", System.getProperty("line.separator")));
                 } finally {
                     if (xmlStream != null) {
                         xmlStream.close();

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1239,8 +1239,8 @@ public class XMLTest {
                     for (int numRead; (numRead = in.read(buffer, 0, buffer.length)) > 0; ) {
                         expected.append(buffer, 0, numRead);
                     }
-                    assertEquals(expected.toString().replaceAll("\\n|\\r\\n", System.getProperty("line.separator")),
-                            actualString.replaceAll("\\n|\\r\\n", System.getProperty("line.separator")));
+                    assertEquals(expected.toString().replaceAll("\\n|\\r\\n", System.lineSeparator()),
+                            actualString.replaceAll("\\n|\\r\\n", System.lineSeparator()));
                 } finally {
                     if (xmlStream != null) {
                         xmlStream.close();

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1223,32 +1223,18 @@ public class XMLTest {
 
     @Test
     public void testIndentComplicatedJsonObjectWithArrayAndWithConfig(){
-        try {
-            InputStream jsonStream = null;
-            try {
-                jsonStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.json");
-                final JSONObject object = new JSONObject(new JSONTokener(jsonStream));
-                String actualString = XML.toString(object, null, XMLParserConfiguration.KEEP_STRINGS,2);
-                InputStream xmlStream = null;
-                try {
-                    xmlStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.xml");
-                    int bufferSize = 1024;
-                    char[] buffer = new char[bufferSize];
-                    StringBuilder expected = new StringBuilder();
-                    Reader in = new InputStreamReader(xmlStream, "UTF-8");
-                    for (int numRead; (numRead = in.read(buffer, 0, buffer.length)) > 0; ) {
-                        expected.append(buffer, 0, numRead);
-                    }
-                    assertEquals(expected.toString(), actualString.replaceAll("\\n|\\r\\n", System.getProperty("line.separator")));
-                } finally {
-                    if (xmlStream != null) {
-                        xmlStream.close();
-                    }
+        try (InputStream jsonStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.json")) {
+            final JSONObject object = new JSONObject(new JSONTokener(jsonStream));
+            String actualString = XML.toString(object, null, XMLParserConfiguration.KEEP_STRINGS, 2);
+            try (InputStream xmlStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.xml")) {
+                int bufferSize = 1024;
+                char[] buffer = new char[bufferSize];
+                StringBuilder expected = new StringBuilder();
+                Reader in = new InputStreamReader(xmlStream, "UTF-8");
+                for (int numRead; (numRead = in.read(buffer, 0, buffer.length)) > 0; ) {
+                    expected.append(buffer, 0, numRead);
                 }
-            } finally {
-                if (jsonStream != null) {
-                    jsonStream.close();
-                }
+                assertEquals(expected.toString(), actualString);
             }
         } catch (IOException e) {
             fail("file writer error: " +e.getMessage());

--- a/src/test/java/org/json/junit/data/GenericBean.java
+++ b/src/test/java/org/json/junit/data/GenericBean.java
@@ -9,7 +9,7 @@ import java.io.StringReader;
  * @param <T>
  *            generic number value
  */
-public class GenericBean<T extends Number & Comparable<T>> implements MyBean {
+public class GenericBean<T extends Number> implements MyBean {
     /**
      * @param genericValue
      *            value to initiate with


### PR DESCRIPTION
## Problem:
<!-- Explain the context and why you're making that change. What is the problem you're trying to solve? In some cases there is not a problem and this can be thought of being the motivation for your change. -->
In this test, the contents of an XML file and a JSON file is getting parsed and compared. But XML does not specify the order of the elements in the String, what means that the actual and the expected string cannot be directly compared for equality.
The flaky test was found by using the [NonDex](https://mvnrepository.com/artifact/edu.illinois/nondex-maven-plugin) tool.

https://github.com/hofi1/JSON-java/blob/01727fd0ed00c1f1f5582bdc97244356ac029f3b/src/test/java/org/json/junit/XMLTest.java#L1242

## Solution:
<!--Changed the assert statement from a JUnit Assertion to an XML Assertion and wrapped it in a default root element. This default root element is necessary, because of the specification of well-formed XML files. -->
To fix this assertion without the import of a new XMLAssertion library, just like in other PRs discussed, the XML String gets converted to a JSON Object and afterward compared for similarity. This is needed due to the fact that XML Objects do not offer a `similarity()` method.  

https://github.com/hofi1/JSON-java/blob/f4f7fc4a80f0999ec0b4957a7b7cc87fd49dcfa7/src/test/java/org/json/junit/XMLTest.java#L1242

## Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
The test is deterministic and not flaky. This improves the quality of the test and reduces the time to search for the bug during future development, as well as the need for reruns of the pipeline. 

## Reproduce
```shell
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.json.junit.XMLTest#testIndentComplicatedJsonObjectWithArrayAndWithConfig
``` 